### PR TITLE
feat: normalize and export person data

### DIFF
--- a/src/main/java/com/example/batch/config/ProcessorConfig.java
+++ b/src/main/java/com/example/batch/config/ProcessorConfig.java
@@ -1,0 +1,18 @@
+package com.example.batch.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.batch.item.ItemProcessor;
+
+import com.example.batch.model.Person;
+import com.example.batch.processor.PersonItemProcessor;
+
+@Configuration
+public class ProcessorConfig {
+
+    @Bean
+    public ItemProcessor<Person, Person> itemProcessor() {
+        return new PersonItemProcessor();
+    }
+}
+

--- a/src/main/java/com/example/batch/config/WriterConfig.java
+++ b/src/main/java/com/example/batch/config/WriterConfig.java
@@ -1,0 +1,32 @@
+package com.example.batch.config;
+
+import org.springframework.batch.item.file.FlatFileItemWriter;
+import org.springframework.batch.item.file.transform.DelimitedLineAggregator;
+import org.springframework.batch.item.file.transform.BeanWrapperFieldExtractor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResource;
+
+import com.example.batch.model.Person;
+
+@Configuration
+public class WriterConfig {
+
+    @Bean
+    public ItemWriter<Person> itemWriter() {
+        FlatFileItemWriter<Person> writer = new FlatFileItemWriter<>();
+        writer.setResource(new FileSystemResource("output.txt"));
+
+        DelimitedLineAggregator<Person> aggregator = new DelimitedLineAggregator<>();
+        aggregator.setDelimiter(",");
+
+        BeanWrapperFieldExtractor<Person> fieldExtractor = new BeanWrapperFieldExtractor<>();
+        fieldExtractor.setNames(new String[] {"id", "name", "age"});
+        aggregator.setFieldExtractor(fieldExtractor);
+
+        writer.setLineAggregator(aggregator);
+        return writer;
+    }
+}
+

--- a/src/main/java/com/example/batch/processor/PersonItemProcessor.java
+++ b/src/main/java/com/example/batch/processor/PersonItemProcessor.java
@@ -1,0 +1,21 @@
+package com.example.batch.processor;
+
+import org.springframework.batch.item.ItemProcessor;
+
+import com.example.batch.model.Person;
+
+/**
+ * ItemProcessor implementation that normalizes Person data.
+ * Currently it trims and converts the person's name to upper case.
+ */
+public class PersonItemProcessor implements ItemProcessor<Person, Person> {
+
+    @Override
+    public Person process(Person item) {
+        if (item.getName() != null) {
+            item.setName(item.getName().trim().toUpperCase());
+        }
+        return item;
+    }
+}
+


### PR DESCRIPTION
## Summary
- normalize person names using a custom ItemProcessor
- export processed records to a flat file with a new ItemWriter
- wire reader, processor, and writer into the batch step

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.duoc:batch-demo:0.0.1-SNAPSHOT: The following artifacts could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689d2271646c8331bc2fb7a85b994561